### PR TITLE
Namespace typo fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "PHP Package for CrunchzApp WhatsApp API",
     "autoload": {
         "psr-4": {
-            "Crunchzapp\\": "src/"
+            "CrunchzApp\\": "src/"
         }
     },
     "authors": [
@@ -15,7 +15,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Crunchzapp\\CrunchzAppServiceProvider"
+                "CrunchzApp\\CrunchzAppServiceProvider"
             ]
         }
     },

--- a/src/Base/OtpBase.php
+++ b/src/Base/OtpBase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Crunchzapp\Base;
+namespace CrunchzApp\Base;
 
 class OtpBase {
 

--- a/src/Base/WhatsAppBase.php
+++ b/src/Base/WhatsAppBase.php
@@ -2,10 +2,10 @@
 
 namespace CrunchzApp\Base;
 
-use Crunchzapp\Traits\ChatTrait;
-use Crunchzapp\Traits\ContactTrait;
-use Crunchzapp\Traits\GroupTrait;
-use Crunchzapp\Traits\MessageTrait;
+use CrunchzApp\Traits\ChatTrait;
+use CrunchzApp\Traits\ContactTrait;
+use CrunchzApp\Traits\GroupTrait;
+use CrunchzApp\Traits\MessageTrait;
 
 class WhatsAppBase {
     protected $client;

--- a/src/CrunchzApp.php
+++ b/src/CrunchzApp.php
@@ -3,7 +3,7 @@
 namespace CrunchzApp;
 
 use CrunchzApp\Services\ChannelService;
-use Crunchzapp\Services\OtpService;
+use CrunchzApp\Services\OtpService;
 
 final class CrunchzApp {
 

--- a/src/Services/OtpService.php
+++ b/src/Services/OtpService.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Crunchzapp\Services;
+namespace CrunchzApp\Services;
 
-use Crunchzapp\Base\OtpBase;
+use CrunchzApp\Base\OtpBase;
 use Illuminate\Support\Facades\Http;
 
 final class OtpService extends OtpBase

--- a/src/Traits/ChatTrait.php
+++ b/src/Traits/ChatTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Crunchzapp\Traits;
+namespace CrunchzApp\Traits;
 
 trait ChatTrait {
 

--- a/src/Traits/ContactTrait.php
+++ b/src/Traits/ContactTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Crunchzapp\Traits;
+namespace CrunchzApp\Traits;
 
 trait ContactTrait {
 

--- a/src/Traits/GroupTrait.php
+++ b/src/Traits/GroupTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Crunchzapp\Traits;
+namespace CrunchzApp\Traits;
 
 trait GroupTrait {
 

--- a/src/Traits/MessageTrait.php
+++ b/src/Traits/MessageTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Crunchzapp\Traits;
+namespace CrunchzApp\Traits;
 
 trait MessageTrait {
     public function startTyping(): static


### PR DESCRIPTION
Hello,

This PR fix issue with namespace  I've change everything to CrunchzApp instead of Crunzchapp 
Now it works as expected

Hope that helps

Regards